### PR TITLE
Fix collapsed navigation, when using mobile phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+NoTrollsAllowed home page
+=========================
+
+This is a code for https://notrollsallowed.com
+
+Developing locally
+------------------
+
+```bash
+make serve
+```
+
+Open page at http://localhost:8080
+
+References
+----------
+
+ * [Silex](https://silex.symfony.com/) Framework in use

--- a/views/index.html.twig
+++ b/views/index.html.twig
@@ -48,7 +48,7 @@
 <div class="navcontain">
 	<div class="navbar default unfixed" id="nav2">
 		<div class="row">
-			<a class="toggle" gumby-trigger="#nav2 > ul" href="#"><i class="icon-menu"></i></a>
+			<a class="toggle" href="#"><i class="icon-menu"></i></a>
 			<div class="four columns logo"></div>
 			<ul class="eight columns">
 				<li>
@@ -155,6 +155,7 @@
 	<script gumby-touch="/js/libs" src="/js/libs/gumby.js"></script>
 	<script src="/js/libs/ui/gumby.retina.js"></script>
 	<script src="/js/libs/gumby.init.js"></script>
+	<script src="/js/nav-fix.js"></script>
 
 	<!--
 	Google's recommended deferred loading of JS

--- a/web/js/nav-fix.js
+++ b/web/js/nav-fix.js
@@ -1,0 +1,6 @@
+$(document).ready(function () {
+    $('#nav2 a.toggle').click(function () {
+        $("#nav2 > .row > ul").toggleClass('active');
+        $("#nav2").toggleClass('fixed');
+    });
+});


### PR DESCRIPTION
Using workaround with `jQuery` to simulate `gumby-trigger`.
`gumby-trigger` [suppose to](https://gumbyframework.com/docs/components/#!/toggles-switches) toggle `active` class.
![nta-navbar-no-working](https://user-images.githubusercontent.com/1453957/43403386-980bdaea-941d-11e8-8a0d-273d6525811c.jpg)

Also toggling `fixed` class, so drop down menu would not be bellow main text.
![nta-navba-after](https://user-images.githubusercontent.com/1453957/43403399-a052713c-941d-11e8-8603-4632a0e3e865.jpg)

:notebook: Could be related to: `ReferenceError: reference to undefined property "triggered"`
:notebook: Tried fixing `#nav2 > ul` to `#nav2 > .row > ul` (because element was not found), but it was not enough